### PR TITLE
Fix addFriend function

### DIFF
--- a/src/classes/User.ts
+++ b/src/classes/User.ts
@@ -275,10 +275,8 @@ export class User {
    * Send a friend request to a user
    */
   async addFriend() {
-    const username = this.username + "#" + this.discriminator;
-    
     const user = await this.#collection.client.api.post(`/users/friend`, {
-      username
+      username: this.username + "#" + this.discriminator
     });
 
     return this.#collection.getOrCreate(user._id, user);

--- a/src/classes/User.ts
+++ b/src/classes/User.ts
@@ -276,7 +276,7 @@ export class User {
    */
   async addFriend() {
     const user = await this.#collection.client.api.post(`/users/friend`, {
-      username: this.username + "#" + this.discriminator
+      username: this.username + "#" + this.discriminator,
     });
 
     return this.#collection.getOrCreate(user._id, user);

--- a/src/classes/User.ts
+++ b/src/classes/User.ts
@@ -275,8 +275,10 @@ export class User {
    * Send a friend request to a user
    */
   async addFriend() {
+    const username = this.username + "#" + this.discriminator;
+    
     const user = await this.#collection.client.api.post(`/users/friend`, {
-      username: this.username,
+      username
     });
 
     return this.#collection.getOrCreate(user._id, user);


### PR DESCRIPTION
The function `async User::addFriend` was erroneously trying to friend someone with just their username (presumably hasn't been changed since the pre-discriminator days).
This was fine in Revite but began to cause issues in Lavender/Frontend which actually used this function, resulting in an error and no friend request being sent.

This PR fixes it to also add the discriminator.